### PR TITLE
Relocate getHost

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "payment",
         "purchase"
     ],
-    "homepage": "https://github.com/kovena/omnipay-kovena",
+    "homepage": "https://github.com/kovena-technology/omnipay-kovena",
     "type": "library",
     "license": "MIT",
     "authors": [

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -11,14 +11,6 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
 	use HasGatewayParameters;
 	use HasBookingParameters;
 	
-	protected $liveHost = 'https://gateway.kovena.com/v1';
-	protected $testHost = 'https://staging-gateway.kovena.com/v1';
-
-
-	public function getHost(){
-		return $this->getTestMode() ? $this->testHost : $this->liveHost;
-	}
-	
 	abstract public function getEndpoint();
 	
     public function getHttpMethod()

--- a/src/Trails/HasGatewayParameters.php
+++ b/src/Trails/HasGatewayParameters.php
@@ -10,6 +10,13 @@ use Omnipay\Kovena\Message\Response;
 
 trait HasGatewayParameters
 {
+	protected $liveHost = 'https://gateway.kovena.com/v1';
+	protected $testHost = 'https://staging-gateway.kovena.com/v1';
+
+	public function getHost()
+	{
+		return $this->getTestMode() ? $this->testHost : $this->liveHost;
+	}
 
 	/**
 	 * Get the gateway API Key.


### PR DESCRIPTION
Moves the `getHost()` method so that `getAccessTokenHeader()` can be called directly from the gateway.